### PR TITLE
Add EmbeddedToken option

### DIFF
--- a/helpers.go
+++ b/helpers.go
@@ -8,9 +8,13 @@ import (
 	"crypto/rand"
 	"crypto/x509"
 	"encoding/pem"
+	"fmt"
+	"strings"
 
 	"golang.org/x/crypto/ssh"
 
+	"github.com/go-git/go-git/v5/plumbing/transport"
+	"github.com/go-git/go-git/v5/plumbing/transport/http"
 	"github.com/google/go-github/v32/github"
 	"golang.org/x/oauth2"
 )
@@ -68,4 +72,18 @@ func injectDeploymentKey(ctx context.Context, client *github.Client, user, repoN
 		Key:   &key,
 	})
 	return err
+}
+
+// TODO support other git providers
+func embedGitToken(url string, auth transport.AuthMethod) (string, error) {
+	if strings.Contains(url, "github.com") {
+		basic, ok := auth.(*http.BasicAuth)
+		if !ok {
+			return "", fmt.Errorf("unsupported auth method: %T", auth)
+		}
+
+		return strings.Replace(url, "github.com", fmt.Sprintf("%s@github.com", basic.Password), 1), nil
+	}
+
+	return "", fmt.Errorf("unsupported url: %s", url)
 }

--- a/new.go
+++ b/new.go
@@ -2,6 +2,7 @@ package gosimplegit
 
 import (
 	"context"
+	"fmt"
 	"os"
 
 	"github.com/go-git/go-git/v5"
@@ -79,9 +80,19 @@ func (c *Repository) open_or_clone() error {
 
 func (c *Repository) clone() error {
 	Info("Cloning from " + c.url + " on branch " + c.branches[0] + " into " + c.root + "\n")
+
+	cloneURL := c.url
+	if c.embedToken == true {
+		var err error
+		cloneURL, err = embedGitToken(c.url, c.auth)
+		if err != nil {
+			return fmt.Errorf("embedding token failed with: %s", err)
+		}
+	}
+
 	var err0 error
 	c.repo, err0 = git.PlainCloneContext(c.ctx, c.root, false, &git.CloneOptions{
-		URL:      c.url,
+		URL:      cloneURL,
 		Progress: os.Stdout,
 		Auth:     c.auth,
 	})

--- a/new.go
+++ b/new.go
@@ -84,7 +84,7 @@ func (c *Repository) clone() error {
 	cloneURL := c.url
 	if c.embedToken == true {
 		var err error
-		cloneURL, err = embedGitToken(c.url, c.auth)
+		cloneURL, err = embedGitToken(cloneURL, c.auth)
 		if err != nil {
 			return fmt.Errorf("embedding token failed with: %s", err)
 		}

--- a/options.go
+++ b/options.go
@@ -35,6 +35,23 @@ func Token(token string) Option {
 	}
 }
 
+/* EmbeddedToken is an Option to set the repository token.
+ * the token will also be embedded in the remote url.
+ *
+ * token: The token to use.
+ */
+func EmbeddedToken(token string) Option {
+	return func(c *Repository) error {
+		c.embedToken = true
+		c.auth = &http.BasicAuth{
+			Username: fakeUserforTokenAuth,
+			Password: token,
+		}
+
+		return nil
+	}
+}
+
 /* SSHKey is an Option to set the repository SSH key.
  *
  * key: The key to use.

--- a/types.go
+++ b/types.go
@@ -40,6 +40,7 @@ type Repository struct {
 	user                user
 	branches            []string
 	usingSpecificBranch bool
+	embedToken          bool
 }
 
 func (c *Repository) Repo() *git.Repository {


### PR DESCRIPTION
Here I moved an embedded token option from tau-cli to here.  This prevents the token from being displayed, and makes Embedding a token a simple endeavor.

Tests passing: https://asciinema.org/a/TO6xtvx2uKkL25hVeORhOVhxX